### PR TITLE
Obstacle avoidance

### DIFF
--- a/include/NeoLocalPlanner.hpp
+++ b/include/NeoLocalPlanner.hpp
@@ -189,7 +189,7 @@ private:
   uint64_t m_update_counter = 0;
   double m_last_control_values[3] = {};
   geometry_msgs::msg::Twist m_last_cmd_vel;
-    tf2::Duration transform_tolerance_;
+  tf2::Duration transform_tolerance_;
 
 protected:
   double acc_lim_x = 0;

--- a/include/NeoLocalPlanner.hpp
+++ b/include/NeoLocalPlanner.hpp
@@ -47,6 +47,7 @@
 #include "nav2_core/controller.hpp"
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_costmap_2d/footprint_collision_checker.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "pluginlib/class_loader.hpp"
 #include "pluginlib/class_list_macros.hpp"
@@ -155,11 +156,15 @@ private:
 
   std::mutex m_mutex;
   nav_msgs::msg::Odometry::SharedPtr m_odometry;
+  geometry_msgs::msg::PointStamped m_carrot_pose;
 
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr m_odom_sub;
+  rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr m_lookahead_point_pub;
   rclcpp_lifecycle::LifecycleNode::WeakPtr node_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> m_local_plan_pub;
+  std::unique_ptr<nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>>
+  collision_checker_;
 
   std::string m_global_frame = "map";
   std::string m_local_frame;
@@ -184,6 +189,7 @@ private:
   uint64_t m_update_counter = 0;
   double m_last_control_values[3] = {};
   geometry_msgs::msg::Twist m_last_cmd_vel;
+    tf2::Duration transform_tolerance_;
 
 protected:
   double acc_lim_x = 0;

--- a/src/NeoLocalPlanner.cpp
+++ b/src/NeoLocalPlanner.cpp
@@ -232,9 +232,9 @@ geometry_msgs::msg::TwistStamped NeoLocalPlanner::computeVelocityCommands(
       "lookupTransform(m_base_frame, m_global_frame) failed");
   }
 
-  geometry_msgs::msg::PoseStamped local_goal_pose;
+  geometry_msgs::msg::PoseStamped global_robot_pose;
   try {
-    tf_->transform(position, local_goal_pose, "map", transform_tolerance_);
+    tf_->transform(position, global_robot_pose, "map", transform_tolerance_);
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN_THROTTLE(
       logger_, *clock_, 1.0,
@@ -242,7 +242,7 @@ geometry_msgs::msg::TwistStamped NeoLocalPlanner::computeVelocityCommands(
   }
   auto global_goal_pose = m_global_plan.poses.back();
   double dist_goal = nav2_util::geometry_utils::euclidean_distance(
-    local_goal_pose.pose.position,
+    global_robot_pose.pose.position,
     global_goal_pose.pose.position
   );
 

--- a/src/NeoLocalPlanner.cpp
+++ b/src/NeoLocalPlanner.cpp
@@ -711,14 +711,12 @@ geometry_msgs::msg::TwistStamped NeoLocalPlanner::computeVelocityCommands(
   is_emergency_brake = is_emergency_brake && fabs(control_vel_x) >= 0;
 
   // apply low pass filter
-
   control_vel_x = control_vel_x * low_pass_gain + m_last_control_values[0] * (1 - low_pass_gain);
   control_vel_y = control_vel_y * low_pass_gain + m_last_control_values[1] * (1 - low_pass_gain);
   control_yawrate = control_yawrate * low_pass_gain + m_last_control_values[2] *
     (1 - low_pass_gain);
 
   // apply acceleration limits
-
   if (m_robot_direction == -1.0) {
     if (!is_goal_target) {
       control_vel_x = fmin(fabs(control_vel_x), fabs(m_last_cmd_vel.linear.x + acc_lim_x * dt));

--- a/src/NeoLocalPlanner.cpp
+++ b/src/NeoLocalPlanner.cpp
@@ -427,7 +427,7 @@ geometry_msgs::msg::TwistStamped NeoLocalPlanner::computeVelocityCommands(
       } else {
         pose = tf2::Transform(
           createQuaternionFromYaw(tf2::getYaw(pose.getRotation()) + start_yawrate * delta_time),
-          pose * tf2::Vector3(start_vel_x * delta_time, start_vel_y * delta_time, 0));
+          pose * tf2::Vector3(m_robot_direction * start_vel_x * delta_time, start_vel_y * delta_time, 0));
       }
 
       // Interpolating the spline further


### PR DESCRIPTION
This PR mainly fixes the local plan projections. Because of the sudden unfeasible local plan projections, sudden dynamic "static"  obstacles weren't handled. The robot stopped only at the point and reported about the obstacle only after the scanner stop was triggered. The entire pipeline had to rely upon the safety scanners for a safe stop on collision avoidance. Rather than relying upon the safety scanners, with the improved projections given in this PR, the local planner will be able to see the obstacles well in advance, depending on the lookahead distance and stop the robot even before getting into the scanner stop. Thus with this approach, the user would be able to make the robot go through recovery behaviors, thus allowing to find an alternate path for the robot to navigate. 