### PR TITLE
Addressing Issue 40- remove costmap convertors from package xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,6 @@
 
     <buildtool_depend>ament_cmake</buildtool_depend>
   
-    <depend>costmap_converter</depend>
-    <depend>costmap_converter_msgs</depend>
     <depend>geometry_msgs</depend>
     <depend>nav2_core</depend>
     <depend>nav2_costmap_2d</depend>


### PR DESCRIPTION
removed both `costmap_converter` and `costmap_converter_msgs` dependency from package.xml #40 